### PR TITLE
Enable re-queue of jobs after timeout

### DIFF
--- a/tutorials/video_classification_example/slurm.py
+++ b/tutorials/video_classification_example/slurm.py
@@ -37,7 +37,8 @@ def copy_and_run_with_config(run_fn, run_config, directory, **cluster_config):
     os.chdir(working_directory)
     print(f"Running at {working_directory}")
 
-    executor = submitit.SlurmExecutor(folder=working_directory)
+    executor = submitit.SlurmExecutor(folder=working_directory,
+                                      max_num_timeout=3)
     executor.update_parameters(**cluster_config)
     job = executor.submit(InitAndRun(run_fn, run_config))
     print(f"job_id: {job}")

--- a/tutorials/video_classification_example/train.py
+++ b/tutorials/video_classification_example/train.py
@@ -435,7 +435,7 @@ def main():
             args,
             args.working_directory,
             job_name=args.job_name,
-            time="72:00:00",
+            time=4320,
             partition=args.partition,
             gpus_per_node=args.gpus,
             ntasks_per_node=args.gpus,


### PR DESCRIPTION
## Motivation and Context

Many training jobs require re-queuing after time out, as they take longer than 72 hours. There were a couple issues in the current implementation of the example video classifier code that are fixed in this PR.

1. The `time` parameter in SlurmExecutor refers to [timeout in minutes](https://github.com/facebookincubator/submitit/blob/2736b95476c36b2fd9f9ee40102ead03935abe4b/submitit/slurm/slurm.py#L251) so replaced the default value from `72:00:00` to 4320.
2. The `init_and_run` function was not checkpointable by submitit. Refactored it to add default checkpointing.

## How Has This Been Tested

Ran the job with time = 5  minutes and it was able to requeue correctly 3 times after being timed out with the same config options. Since it runs on the same output directory, it is able to pick the last saved checkpoint and continue training from there.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

