### PR TITLE
Relax fvcore version constrain.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
     description="A video understanding deep learning library.",
     python_requires=">=3.7",
     install_requires=[
-        "fvcore>=0.1.4",
+        "fvcore",
         "av",
         "parameterized",
         "iopath",


### PR DESCRIPTION
Currently we restrict fvcore>0.1.4 to work with PTV. But this constraint is not needed.
