### PR TITLE
Fix error in classfication training example.

### DIFF
--- a/tutorials/video_classification_example/train.py
+++ b/tutorials/video_classification_example/train.py
@@ -359,7 +359,7 @@ class LimitDataset(torch.utils.data.Dataset):
         return next(self.dataset_iter)
 
     def __len__(self):
-        return self.dataset.num_videos()
+        return self.dataset.num_videos
 
 
 def main():


### PR DESCRIPTION
This should resolve the following github issue - https://github.com/facebookresearch/pytorchvideo/issues/71
