### PR TITLE
Fix LabeledVideoPaths type hint and inheritance issue

### DIFF
--- a/pytorchvideo/data/labeled_video_paths.py
+++ b/pytorchvideo/data/labeled_video_paths.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import os
 import pathlib
-from typing import List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 
 from iopath.common.file_io import g_pathmgr
 from torchvision.datasets.folder import make_dataset
@@ -23,13 +23,13 @@ class LabeledVideoPaths:
         - If it is a directory path it uses the LabeledVideoPaths.from_directory function.
         - If it's a file it uses the LabeledVideoPaths.from_csv file.
         Args:
-            file_path (str): The path to the file to be read.
+            data_path (str): The path to the file to be read.
         """
 
         if g_pathmgr.isfile(data_path):
-            return LabeledVideoPaths.from_csv(data_path)
+            return cls.from_csv(data_path)
         elif g_pathmgr.isdir(data_path):
-            return LabeledVideoPaths.from_directory(data_path)
+            return cls.from_directory(data_path)
         else:
             raise FileNotFoundError(f"{data_path} not found.")
 
@@ -107,7 +107,7 @@ class LabeledVideoPaths:
         return cls(video_paths_and_label)
 
     def __init__(
-        self, paths_and_labels: List[Tuple[str, Optional[int]]], path_prefix=""
+        self, paths_and_labels: List[Tuple[str, Optional[int]]], path_prefix: str = ""
     ) -> None:
         """
         Args:
@@ -117,12 +117,12 @@ class LabeledVideoPaths:
         self._paths_and_labels = paths_and_labels
         self._path_prefix = path_prefix
 
-    def path_prefix(self, prefix):
+    def path_prefix(self, prefix: str) -> None:
         self._path_prefix = prefix
 
     path_prefix = property(None, path_prefix)
 
-    def __getitem__(self, index: int) -> Tuple[str, int]:
+    def __getitem__(self, index: int) -> Tuple[str, Dict[str, int]]:
         """
         Args:
             index (int): the path and label index.


### PR DESCRIPTION
## Motivation and Context

Fix the following error in `pytorchvideo/data/labeled_video_paths.py`:

- Inheritance issue in `LabeledVideoPaths.from_path` which will invoke `LabeledVideoPaths`'s `.from_path` instead of subclasses' `.from_path`
- Incorrect variable name in LabeledVideoPaths methods
- Incorrect type hint in LabeledVideoPaths methods

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

```python
# create a subclass of LabeledVideoPaths
class ChildLabeledVideoPaths(LabeledVideoPaths):
    @classmethod
    def from_csv(cls, file_path: str) -> LabeledVideoPaths:
        print("subclass from_csv")
        super().from_csv(file_path)

# Instantiate the child class
child_paths = ChildLabeledVideoPaths.from_path("test.csv")

# If "subclass from_csv" is printed, then the code passes the test
```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

