### PR TITLE
Fix edge case issue in `uniform_temporal_sampling`

### DIFF
--- a/pytorchvideo/transforms/functional.py
+++ b/pytorchvideo/transforms/functional.py
@@ -37,7 +37,7 @@ def uniform_temporal_subsample(
     assert num_samples > 0 and t > 0
     # Sample by nearest neighbor interpolation if num_samples > t.
     indices = torch.linspace(0, t - 1, num_samples)
-    indices = torch.clamp(indices, 0, t - 1).long()
+    indices = torch.clamp(indices, 0, t - 1).round().long()
     return torch.index_select(x, temporal_dim, indices)
 
 


### PR DESCRIPTION
## Motivation and Context

Current behavior of the `uniform_temporal_sampling` function has an undesirable property when dealing with smaller than `num_samples` input.

For example:
```python
uniform_temporal_subsample(torch.arange(4), num_samples=4, temporal_dim=0)
# tensor([0, 1, 2, 3])  (looks good)

uniform_temporal_subsample(torch.arange(4), num_samples=5, temporal_dim=0)
# tensor([0, 0, 1, 2, 3]) (looks good)

uniform_temporal_subsample(torch.arange(4), num_samples=6, temporal_dim=0)
# tensor([0, 0, 1, 1, 2, 3]) (looks good)

uniform_temporal_subsample(torch.arange(4), num_samples=7, temporal_dim=0)
# tensor([0, 0, 1, 1, 2, 2, 3]) (looks good)

uniform_temporal_subsample(torch.arange(4), num_samples=8, temporal_dim=0)
# tensor([0, 0, 0, 1, 1, 2, 2, 3]) (ISSUE: should be [0, 0, 1, 1, 2, 2, 3, 3])

uniform_temporal_subsample(torch.arange(4), num_samples=9, temporal_dim=0)
# tensor([0, 0, 0, 1, 1, 1, 2, 2, 3])  (ISSUE: should be [0, 0, 0, 1, 1, 2, 2, 3, 3])
```

## How Has This Been Tested

I have tested the implementation myself, but I have not created a test for it.


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

