### PR TITLE
torch.quantization --> torch.ao.quantization in vision for pytorchvideo

### DIFF
--- a/pytorchvideo/layers/accelerator/mobile_cpu/convolutions.py
+++ b/pytorchvideo/layers/accelerator/mobile_cpu/convolutions.py
@@ -18,6 +18,12 @@ from .conv_helper import (
     _Reshape,
 )
 
+TORCH_VERSION: Tuple[int, ...] = tuple(int(x) for x in torch.__version__.split(".")[:2])
+if TORCH_VERSION >= (1, 11):
+    from torch.ao.quantization import fuse_modules
+else:
+    from torch.quantization import fuse_modules
+
 
 class Conv3dPwBnAct(EfficientBlockBase):
     """
@@ -106,7 +112,7 @@ class Conv3dPwBnAct(EfficientBlockBase):
         self.kernel.eval()
         # First fuse conv and bn if bn exists.
         if hasattr(self.kernel, "bn"):
-            self.kernel = torch.quantization.fuse_modules(self.kernel, ["conv", "bn"])
+            self.kernel = fuse_modules(self.kernel, ["conv", "bn"])
 
         batch_size = input_blob_size[0]
         input_THW_tuple = input_blob_size[2:]
@@ -137,9 +143,7 @@ class Conv3dPwBnAct(EfficientBlockBase):
         self.kernel.act.convert(input_blob_size, **kwargs)
         # Fuse act with conv after conv3d -> conv2d if act is relu
         if self.act == "relu":
-            self.kernel = torch.quantization.fuse_modules(
-                self.kernel, ["conv", "act.act"]
-            )
+            self.kernel = fuse_modules(self.kernel, ["conv", "act.act"])
         # Insert reshape layers before/after conv2d
         self.kernel = nn.Sequential(
             _Reshape(self._input_tensor_reshape_size),
@@ -245,7 +249,7 @@ class Conv3d3x3x3DwBnAct(EfficientBlockBase):
         self.kernel.eval()
         # Fuse conv and bn if bn exists.
         if hasattr(self.kernel, "bn"):
-            self.kernel = torch.quantization.fuse_modules(self.kernel, ["conv", "bn"])
+            self.kernel = fuse_modules(self.kernel, ["conv", "bn"])
         self.kernel.conv = _Conv3dTemporalKernel3Decomposed(
             self.kernel.conv, input_blob_size[2:]
         )
@@ -364,7 +368,7 @@ class Conv3dTemporalKernel1BnAct(EfficientBlockBase):
         self.kernel.eval()
         # First fuse conv and bn if bn exists.
         if hasattr(self.kernel, "bn"):
-            self.kernel = torch.quantization.fuse_modules(self.kernel, ["conv", "bn"])
+            self.kernel = fuse_modules(self.kernel, ["conv", "bn"])
 
         self.kernel.conv = _Conv3dTemporalKernel1Decomposed(
             self.kernel.conv, input_blob_size[2:]
@@ -479,7 +483,7 @@ class Conv3d3x1x1BnAct(EfficientBlockBase):
         self.kernel.eval()
         # Fuse conv and bn if bn exists.
         if hasattr(self.kernel, "bn"):
-            self.kernel = torch.quantization.fuse_modules(self.kernel, ["conv", "bn"])
+            self.kernel = fuse_modules(self.kernel, ["conv", "bn"])
         self.kernel.conv = _Conv3dTemporalKernel3Decomposed(
             self.kernel.conv, input_blob_size[2:]
         )
@@ -576,7 +580,7 @@ class Conv3d5x1x1BnAct(EfficientBlockBase):
         self.kernel.eval()
         # Fuse conv and bn if bn exists.
         if hasattr(self.kernel, "bn"):
-            self.kernel = torch.quantization.fuse_modules(self.kernel, ["conv", "bn"])
+            self.kernel = fuse_modules(self.kernel, ["conv", "bn"])
         self.kernel.conv = _Conv3dTemporalKernel5Decomposed(
             self.kernel.conv, input_blob_size[2:]
         )

--- a/tests/benchmark_accelerator_efficient_blocks.py
+++ b/tests/benchmark_accelerator_efficient_blocks.py
@@ -2,12 +2,10 @@
 
 import logging
 import unittest
-from typing import Callable
+from typing import Tuple, Callable
 
 import torch
 import torch.nn as nn
-
-# import torch.quantization.quantize_fx as quantize_fx
 from fvcore.common.benchmark import benchmark
 from pytorchvideo.layers.accelerator.mobile_cpu.convolutions import (
     Conv3d3x3x3DwBnAct,
@@ -17,6 +15,28 @@ from pytorchvideo.models.accelerator.mobile_cpu.residual_blocks import (
     X3dBottleneckBlock,
 )
 from torch.utils.mobile_optimizer import optimize_for_mobile
+
+TORCH_VERSION: Tuple[int, ...] = tuple(int(x) for x in torch.__version__.split(".")[:2])
+if TORCH_VERSION >= (1, 11):
+    from torch.ao.quantization import (
+        get_default_qconfig,
+        prepare,
+        convert,
+        fuse_modules,
+        QuantStub,
+        DeQuantStub,
+        # quantize_fx
+    )
+else:
+    from torch.quantization import (
+        get_default_qconfig,
+        prepare,
+        convert,
+        fuse_modules,
+        QuantStub,
+        DeQuantStub,
+        # quantize_fx
+    )
 
 
 class TestBenchmarkEfficientBlocks(unittest.TestCase):
@@ -86,19 +106,19 @@ class TestBenchmarkEfficientBlocks(unittest.TestCase):
             conv_block.eval()
             if kwargs["quantize"] is True:
                 if kwargs["mode"] == "original":  # manually fuse conv and relu
-                    conv_block.kernel = torch.quantization.fuse_modules(
+                    conv_block.kernel = fuse_modules(
                         conv_block.kernel, ["conv", "act.act"]
                     )
                 conv_block = nn.Sequential(
-                    torch.quantization.QuantStub(),
+                    QuantStub(),
                     conv_block,
-                    torch.quantization.DeQuantStub(),
+                    DeQuantStub(),
                 )
 
-                conv_block.qconfig = torch.quantization.get_default_qconfig("qnnpack")
-                conv_block = torch.quantization.prepare(conv_block)
+                conv_block.qconfig = get_default_qconfig("qnnpack")
+                conv_block = prepare(conv_block)
                 try:
-                    conv_block = torch.quantization.convert(conv_block)
+                    conv_block = convert(conv_block)
                 except Exception as e:
                     logging.info(
                         "benchmark_conv3d_pw_bn_relu: "
@@ -191,19 +211,19 @@ class TestBenchmarkEfficientBlocks(unittest.TestCase):
             conv_block.eval()
             if kwargs["quantize"] is True:
                 if kwargs["mode"] == "original":  # manually fuse conv and relu
-                    conv_block.kernel = torch.quantization.fuse_modules(
+                    conv_block.kernel = fuse_modules(
                         conv_block.kernel, ["conv", "act.act"]
                     )
                 conv_block = nn.Sequential(
-                    torch.quantization.QuantStub(),
+                    QuantStub(),
                     conv_block,
-                    torch.quantization.DeQuantStub(),
+                    DeQuantStub(),
                 )
 
-                conv_block.qconfig = torch.quantization.get_default_qconfig("qnnpack")
-                conv_block = torch.quantization.prepare(conv_block)
+                conv_block.qconfig = get_default_qconfig("qnnpack")
+                conv_block = prepare(conv_block)
                 try:
-                    conv_block = torch.quantization.convert(conv_block)
+                    conv_block = convert(conv_block)
                 except Exception as e:
                     logging.info(
                         "benchmark_conv3d_3x3x3_dw_bn_relu: "
@@ -306,15 +326,15 @@ class TestBenchmarkEfficientBlocks(unittest.TestCase):
             conv_block.eval()
             if kwargs["quantize"] is True:
                 conv_block = nn.Sequential(
-                    torch.quantization.QuantStub(),
+                    QuantStub(),
                     conv_block,
-                    torch.quantization.DeQuantStub(),
+                    DeQuantStub(),
                 )
 
-                conv_block.qconfig = torch.quantization.get_default_qconfig("qnnpack")
-                conv_block = torch.quantization.prepare(conv_block)
+                conv_block.qconfig = get_default_qconfig("qnnpack")
+                conv_block = prepare(conv_block)
                 try:
-                    conv_block = torch.quantization.convert(conv_block)
+                    conv_block = convert(conv_block)
                 except Exception as e:
                     logging.info(
                         "benchmark_x3d_bottleneck_forward: "


### PR DESCRIPTION
Summary: setting up vision for ao migration, uses TORCH_VERSION to handle BC

Reviewed By: z-a-f

Differential Revision: D31436845

