### PR TITLE
Remove lambdas for easy pickling

### DIFF
--- a/pytorchvideo/layers/fusion.py
+++ b/pytorchvideo/layers/fusion.py
@@ -14,6 +14,16 @@ construct them.
 """
 
 
+def max_fusion(x):
+    return torch.max(x, dim=0).values
+
+def sum_fusion(x):
+    return torch.sum(x, dim=0)
+
+def prod_fusion(x):
+    return torch.prod(x, dim=0)
+
+
 def make_fusion_layer(method: str, feature_dims: List[int]):
     """
     Args:
@@ -34,11 +44,11 @@ def make_fusion_layer(method: str, feature_dims: List[int]):
     elif method == "temporal_concat":
         return TemporalConcatFusion(feature_dims)
     elif method == "max":
-        return ReduceFusion(feature_dims, lambda x: torch.max(x, dim=0).values)
+        return ReduceFusion(feature_dims, max_fusion)
     elif method == "sum":
-        return ReduceFusion(feature_dims, lambda x: torch.sum(x, dim=0))
+        return ReduceFusion(feature_dims, sum_fusion)
     elif method == "prod":
-        return ReduceFusion(feature_dims, lambda x: torch.prod(x, dim=0))
+        return ReduceFusion(feature_dims, prod_fusion)
     else:
         raise NotImplementedError(f"Fusion {method} not available.")
 

--- a/pytorchvideo/models/resnet.py
+++ b/pytorchvideo/models/resnet.py
@@ -315,6 +315,8 @@ def create_acoustic_bottleneck_block(
         norm_c=norm_c,
     )
 
+def sum_fusion(x, y):
+    return x + y
 
 def create_res_block(
     *,
@@ -324,7 +326,7 @@ def create_res_block(
     dim_out: int,
     bottleneck: Callable,
     use_shortcut: bool = False,
-    branch_fusion: Callable = lambda x, y: x + y,
+    branch_fusion: Callable = sum_fusion,
     # Conv configs.
     conv_a_kernel_size: Tuple[int] = (3, 1, 1),
     conv_a_stride: Tuple[int] = (2, 1, 1),

--- a/pytorchvideo/models/x3d.py
+++ b/pytorchvideo/models/x3d.py
@@ -12,7 +12,7 @@ from pytorchvideo.layers.swish import Swish
 from pytorchvideo.layers.utils import round_repeats, round_width, set_attributes
 from pytorchvideo.models.head import ResNetBasicHead
 from pytorchvideo.models.net import Net
-from pytorchvideo.models.resnet import BottleneckBlock, ResBlock, ResStage
+from pytorchvideo.models.resnet import BottleneckBlock, ResBlock, ResStage, sum_fusion
 from pytorchvideo.models.stem import ResNetBasicStem
 
 
@@ -318,7 +318,7 @@ def create_x3d_res_block(
             inner_act=inner_act,
         ),
         activation=None if activation is None else activation(),
-        branch_fusion=lambda x, y: x + y,
+        branch_fusion=sum_fusion,
     )
 
 


### PR DESCRIPTION
There are a few lambda functions in place which makes pickling these models impossible. This is an issue for eg model checkpointing or using DDP-spawn in Lightning.

I removed them to make Pickle work