### PR TITLE
Fix label creation for hmdb51

### DIFF
--- a/pytorchvideo/data/hmdb51.py
+++ b/pytorchvideo/data/hmdb51.py
@@ -104,15 +104,20 @@ class Hmdb51LabeledVideoPaths:
                 - "test"
                 - "unused"
         """
+        action_name_to_class = {}
         video_paths_and_label = []
         for file_path in file_paths:
             file_path = pathlib.Path(file_path)
             assert g_pathmgr.exists(file_path), f"{file_path} not found."
             if not (file_path.suffix == ".txt" and "_test_split" in file_path.stem):
-                return RuntimeError(f"Ivalid file: {file_path}")
+                return RuntimeError(f"Invalid file: {file_path}")
 
             action_name = "_"
             action_name = action_name.join((file_path.stem).split("_")[:-2])
+
+            if action_name not in action_name_to_class:
+                action_name_to_class[action_name] = len(action_name_to_class)
+
             with g_pathmgr.open(file_path, "r") as f:
                 for path_label in f.read().splitlines():
                     line_split = path_label.rsplit(None, 1)
@@ -123,7 +128,7 @@ class Hmdb51LabeledVideoPaths:
                     file_path = os.path.join(action_name, line_split[0])
                     meta_tags = line_split[0].split("_")[-6:-1]
                     video_paths_and_label.append(
-                        (file_path, {"label": action_name, "meta_tags": meta_tags})
+                        (file_path, {"label": action_name_to_class[action_name], "meta_tags": meta_tags})
                     )
 
         assert (

--- a/tests/test_data_labeled_video_dataset.py
+++ b/tests/test_data_labeled_video_dataset.py
@@ -228,17 +228,17 @@ class TestLabeledVideoDataset(unittest.TestCase):
                 sample_1 = next(dataset)
                 sample_2 = next(dataset)
 
-                self.assertTrue(sample_1["label"] in [action_1, action_2])
-                if sample_1["label"] == action_2:
+                self.assertTrue(sample_1["label"] in [0, 1])
+                if sample_1["label"] == 1:
                     sample_1, sample_2 = sample_2, sample_1
 
-                self.assertEqual(sample_1["label"], action_1)
+                self.assertEqual(sample_1["label"], 0)
                 self.assertEqual(5, len(sample_1["meta_tags"]))
                 self.assertTrue(
                     sample_1["video"].equal(thwc_to_cthw(data_1).to(torch.float32))
                 )
 
-                self.assertEqual(sample_2["label"], action_2)
+                self.assertEqual(sample_2["label"], 1)
                 self.assertEqual(5, len(sample_2["meta_tags"]))
                 self.assertTrue(
                     sample_2["video"].equal(thwc_to_cthw(data_2).to(torch.float32))


### PR DESCRIPTION
Fix label creation for hmdb51

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

Current hmdb51 dataset implementation returns the name of the action instead of an integer label as explained in #156 . This pull request fixes this issue.

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->
```python
hmdb51 = Hmdb51(
    data_path=root,
    clip_sampler=RandomClipSampler(1),
    decode_audio=False,
    transform=None,
    video_path_prefix=root,
)

clip = next(hmdb51)
```

The `clip` variable contains an integer label:
![image](https://user-images.githubusercontent.com/40604584/153768121-1d5f56a9-ee8e-42d3-8541-0f5fcaa21b4c.png)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

I changed the test to assert integers instead of string labels.