### PR TITLE
Fix typos in MViT param descriptions

### DIFF
--- a/pytorchvideo/layers/attention.py
+++ b/pytorchvideo/layers/attention.py
@@ -220,9 +220,9 @@ class MultiScaleAttention(nn.Module):
                 Otherwise, pool is applied after qkv projection. Default: False.
             residual_pool (bool): If set to True, use Improved Multiscale Vision
                 Transformer's pooling residual connection.
-            depthwise_conv (bool): Wether use depthwise or full convolution for pooling.
-            bias_on (bool): Wether use biases for linear layers.
-            separate_qkv (bool): Wether to use separate or one layer for qkv projections.
+            depthwise_conv (bool): Whether use depthwise or full convolution for pooling.
+            bias_on (bool): Whether use biases for linear layers.
+            separate_qkv (bool): Whether to use separate or one layer for qkv projections.
         """
 
         super().__init__()
@@ -543,9 +543,9 @@ class MultiScaleBlock(nn.Module):
                 Otherwise, pool is applied after qkv projection. Default: False.
             residual_pool (bool): If set to True, use Improved Multiscale Vision
                 Transformer's pooling residual connection.
-            depthwise_conv (bool): Wether use depthwise or full convolution for pooling.
-            bias_on (bool): Wether use biases for linear layers.
-            separate_qkv (bool): Wether to use separate or one layer for qkv projections.
+            depthwise_conv (bool): Whether use depthwise or full convolution for pooling.
+            bias_on (bool): Whether use biases for linear layers.
+            separate_qkv (bool): Whether to use separate or one layer for qkv projections.
         """
         super().__init__()
         self.dim = dim

--- a/pytorchvideo/layers/attention_torchscript.py
+++ b/pytorchvideo/layers/attention_torchscript.py
@@ -204,9 +204,9 @@ class MultiScaleAttention(nn.Module):
                 Otherwise, pool is applied after qkv projection. Default: False.
             residual_pool (bool): If set to True, use Improved Multiscale Vision
                 Transformer's pooling residual connection.
-            depthwise_conv (bool): Wether use depthwise or full convolution for pooling.
-            bias_on (bool): Wether use biases for linear layers.
-            separate_qkv (bool): Wether to use separate or one layer for qkv projections.
+            depthwise_conv (bool): Whether use depthwise or full convolution for pooling.
+            bias_on (bool): Whether use biases for linear layers.
+            separate_qkv (bool): Whether to use separate or one layer for qkv projections.
         """
 
         super().__init__()
@@ -520,9 +520,9 @@ class ScriptableMultiScaleBlock(nn.Module):
                 Otherwise, pool is applied after qkv projection. Default: False.
             residual_pool (bool): If set to True, use Improved Multiscale Vision
                 Transformer's pooling residual connection.
-            depthwise_conv (bool): Wether use depthwise or full convolution for pooling.
-            bias_on (bool): Wether use biases for linear layers.
-            separate_qkv (bool): Wether to use separate or one layer for qkv projections.
+            depthwise_conv (bool): Whether use depthwise or full convolution for pooling.
+            bias_on (bool): Whether use biases for linear layers.
+            separate_qkv (bool): Whether to use separate or one layer for qkv projections.
         """
         super().__init__()
         assert not pool_first

--- a/pytorchvideo/models/vision_transformers.py
+++ b/pytorchvideo/models/vision_transformers.py
@@ -269,9 +269,9 @@ def create_multiscale_vision_transformers(
             Otherwise, pool is applied after qkv projection. Default: False.
         residual_pool (bool): If set to True, use Improved Multiscale Vision
                 Transformer's pooling residual connection.
-        depthwise_conv (bool): Wether use depthwise or full convolution for pooling.
-        bias_on (bool): Wether use biases for linear layers.
-        separate_qkv (bool): Wether to use separate or one layer for qkv projections.
+        depthwise_conv (bool): Whether use depthwise or full convolution for pooling.
+        bias_on (bool): Whether use biases for linear layers.
+        separate_qkv (bool): Whether to use separate or one layer for qkv projections.
         embed_dim_mul (Optional[List[List[int]]]): Dimension multiplication at layer i.
             If X is used, then the next block will increase the embed dimension by X
             times. Format: [depth_i, mul_dim_ratio].


### PR DESCRIPTION
Summary: Fix typos in MViT param descriptions

Differential Revision: D34865114

