### PR TITLE
Add `Streamed` transform.

### DIFF
--- a/pytorchvideo/data/stream.py
+++ b/pytorchvideo/data/stream.py
@@ -1,0 +1,55 @@
+
+from typing import Any, Callable, Dict, Iterable
+from .video import Video
+
+
+class Stream(Iterable):
+    """Create an iterable streaming clips of video data."""
+
+    def __init__(
+        self,
+        video: Video,
+        clip_duration: float,
+        clip_transform: Callable = None,
+        **get_clip_kwargs: Dict[str, Any],
+    ) -> None:
+        """
+        Parameters
+        ----------
+        video : Video
+            PyTorchVideo video instance to stream.
+        clip_duration : float
+            Maximum duration (in seconds) of the returned clip at every iteration.
+        clip_transform : Transform, optional
+            Optional transform to apply to each clip, by default None
+        get_clip_kwargs : Dict[str, Any]
+            Arguments to pass to the underlying video `get_clip` method.
+        """
+        super().__init__()
+        self._clip_duration = clip_duration
+        self._clip_transform = clip_transform
+        self._video = video
+        self._get_clip_kwargs = get_clip_kwargs
+
+    def __iter__(self):
+        current_time = 0.0
+        while current_time < self._video.duration:
+            next_time = min(
+                self._video.duration,
+                current_time + self._clip_duration,
+            )
+            video_data = self._video.get_clip(
+                current_time,
+                next_time,
+                **self._get_clip_kwargs,
+            )
+            current_time = next_time
+
+            if self._clip_transform:
+                video_data = self._clip_transform(video_data)
+
+            yield video_data
+
+    @property
+    def video(self):
+        return self._video


### PR DESCRIPTION
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
There are currently no easy way to handle the processing / transform of large video files without loading them fully in memory (which can blow-up rather quickly).
The proposed solution tackles that issue by making transforms iterable over clip of upper bounded duration.

Example :
```python
iterable_transform = Streamed(
  clip_duration=2.,
  clip_transform=BlaBlaClipTransform(...),
  return_iterable=True,
)
for transformed_clip in iterable_transform(video):
  clip_result = model(transformed_clip)
```
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->
Added unit test and ran `python -m unittest discover -v -s ./tests -p test_transforms.py`.
I'm also using this same code in my own training pipeline.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

