### PR TITLE
add datafarame as input

### DIFF
--- a/pytorchvideo/data/labeled_video_dataset.py
+++ b/pytorchvideo/data/labeled_video_dataset.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 import gc
 import logging
-from typing import Any, Callable, Dict, List, Optional, Tuple, Type
-
+from typing import Any, Callable, Dict, List, Optional, Tuple, Type,Union
+import pandas as pd
 import torch.utils.data
 from pytorchvideo.data.clip_sampling import ClipSampler
 from pytorchvideo.data.video import VideoPathHandler
@@ -145,6 +145,7 @@ class LabeledVideoDataset(torch.utils.data.IterableDataset):
                     )
                     self._loaded_video_label = (video, info_dict, video_index)
                 except Exception as e:
+                    print('error is',e)#necessary to print error
                     logger.debug(
                         "Failed to load video with error: {}; trial {}".format(
                             e,
@@ -251,7 +252,7 @@ class LabeledVideoDataset(torch.utils.data.IterableDataset):
 
 
 def labeled_video_dataset(
-    data_path: str,
+    data:Union[str, pd.DataFrame],
     clip_sampler: ClipSampler,
     video_sampler: Type[torch.utils.data.Sampler] = torch.utils.data.RandomSampler,
     transform: Optional[Callable[[Dict[str, Any]], Dict[str, Any]]] = None,
@@ -292,8 +293,12 @@ def labeled_video_dataset(
         decoder (str): Defines what type of decoder used to decode a video.
 
     """
-    labeled_video_paths = LabeledVideoPaths.from_path(data_path)
-    labeled_video_paths.path_prefix = video_path_prefix
+    if isinstance(data,pd.DataFrame):
+        labeled_video_paths= LabeledVideoPaths.from_df(data)
+    elif isinstance(data,str):
+        labeled_video_paths = LabeledVideoPaths.from_path(data)
+        labeled_video_paths.path_prefix = video_path_prefix
+    
     dataset = LabeledVideoDataset(
         labeled_video_paths,
         clip_sampler,

--- a/pytorchvideo/data/labeled_video_paths.py
+++ b/pytorchvideo/data/labeled_video_paths.py
@@ -8,7 +8,7 @@ from typing import List, Optional, Tuple
 
 from iopath.common.file_io import g_pathmgr
 from torchvision.datasets.folder import make_dataset
-
+import pandas as pd
 
 class LabeledVideoPaths:
     """
@@ -25,11 +25,14 @@ class LabeledVideoPaths:
         Args:
             file_path (str): The path to the file to be read.
         """
+        
 
         if g_pathmgr.isfile(data_path):
             return LabeledVideoPaths.from_csv(data_path)
         elif g_pathmgr.isdir(data_path):
             return LabeledVideoPaths.from_directory(data_path)
+        
+
         else:
             raise FileNotFoundError(f"{data_path} not found.")
 
@@ -66,6 +69,35 @@ class LabeledVideoPaths:
             len(video_paths_and_label) > 0
         ), f"Failed to load dataset from {file_path}."
         return cls(video_paths_and_label)
+
+
+    @classmethod
+    def from_df(cls, df:pd.DataFrame) -> LabeledVideoPaths:
+        """
+        Factory function that creates a LabeledVideoPaths object by reading a dataframe.
+        Sample dataframe
+        df=pd.DataFrame(
+            {
+                "path":["path_to_video_1","path_to_video_2","path_to_video_3"],
+                "label":["label_1","label_2","label_3"]
+            })
+
+        Args:
+            df (dataframe): The dataframe variable.
+        """
+        video_paths_and_label = []
+        for row in df.iterrows():
+            path,label=row[1].values
+            video_paths_and_label.append((path, int(label)))
+
+        assert (
+            len(video_paths_and_label) > 0
+        ), f"Failed to load dataset from df."
+        return cls(video_paths_and_label)
+
+
+
+
 
     @classmethod
     def from_directory(cls, dir_path: str) -> LabeledVideoPaths:


### PR DESCRIPTION
## Motivation and Context
Now user can pass dataframe as input


## How Has This Been Tested

```
train_dataset=labeled_video_dataset(df,
                   clip_sampler=make_clip_sampler("uniform", 5),\
                   transform=train_transform,
                    decode_audio=False)

```
## Update Required
https://github.com/facebookresearch/pytorchvideo/blob/1339169affa8c4beb9cab3cfc5620b11c51ba957/pytorchvideo/data/labeled_video_dataset.py#L254
This variable `data_path`is no changed to `data` because dataframe is not a path.
