### PR TITLE
Fix weight loading issue on pretrained MViT

### DIFF
--- a/pytorchvideo/layers/attention.py
+++ b/pytorchvideo/layers/attention.py
@@ -201,6 +201,8 @@ class MultiScaleAttention(nn.Module):
                                       DropOut
     """
 
+    _version = 2
+
     def __init__(
         self,
         dim: int,
@@ -493,6 +495,37 @@ class MultiScaleAttention(nn.Module):
         if self.dropout_rate > 0.0:
             x = self.proj_drop(x)
         return x, q_shape
+
+    def _load_from_state_dict(
+        self,
+        state_dict,
+        prefix,
+        local_metadata,
+        strict,
+        missing_keys,
+        unexpected_keys,
+        error_msgs,
+    ):
+        version = local_metadata.get("version", None)
+
+        if version is None or version < 2:
+            for layer in ["pool", "norm"]:
+                for pattern in ["q", "k", "v"]:
+                    for type in ["weight", "bias"]:
+                        old_key = f"{prefix}{layer}_{pattern}.{type}"
+                        new_key = f"{prefix}_attention_pool_{pattern}.{layer}.{type}"
+                        if old_key in state_dict:
+                            state_dict[new_key] = state_dict[old_key]
+
+        super()._load_from_state_dict(
+            state_dict,
+            prefix,
+            local_metadata,
+            strict,
+            missing_keys,
+            unexpected_keys,
+            error_msgs,
+        )
 
 
 class MultiScaleBlock(nn.Module):


### PR DESCRIPTION
Fixes #206

I believe d1449fb82ed2fe9458c82d9eb0577f72539f709b broke the ability to load the pre-trained weights on MViT. This is how to reproduce:
```python
from pytorchvideo.models.hub.vision_transformers import mvit_base_16x4
model = mvit_base_16x4(pretrained=True)
```

Returns error on the latest main branch:
```
RuntimeError: Error(s) in loading state_dict for MultiscaleVisionTransformers:
	Missing key(s) in state_dict: "blocks.0.attn._attention_pool_k.pool.weight", "blocks.0.attn._attention_pool_k.norm.weight", "blocks.0.attn._attention_pool_k.norm.bias", "blocks.0.attn._attention_pool_v.pool.weight", "blocks.0.attn._attention_pool_v.norm.weight", "blocks.0.attn._attention_pool_v.norm.bias", "blocks.1.attn._attention_pool_q.pool.weight", "blocks.1.attn._attention_pool_q.norm.weight", "blocks.1.attn._attention_pool_q.norm.bias", "blocks.1.attn._attention_pool_k.pool.weight", "blocks.1.attn._attention_pool_k.norm.weight", "blocks.1.attn._attention_pool_k.norm.bias", "blocks.1.attn._attention_pool_v.pool.weight", "blocks.1.attn._attention_pool_v.norm.weight", "blocks.1.attn._attention_pool_v.norm.bias", "blocks.2.attn._attention_pool_k.pool.weight", "blocks.2.attn._attention_pool_k.norm.weight", "blocks.2.attn._attention_pool_k.norm.bias", "blocks.2.attn._attention_pool_v.pool.weight", "blocks.2.attn._attention_pool_v.norm.weight", "blocks.2.attn._attention_pool_v.norm.bias", "blocks.3.attn._attention_pool_q.pool.weight", "blocks.3.attn._attention_pool_q.norm.weight", "blocks.3.attn._attention_pool_q.norm.bias", "blocks.3.attn._attention_pool_k.pool.weight", "blocks.3.attn._attention_pool_k.norm.weight", "blocks.3.attn._attention_pool_k.norm.bias", "blocks.3.attn._attention_pool_v.pool.weight", "blocks.3.attn._attention_pool_v.norm.weight", "blocks.3.attn._attention_pool_v.norm.bias", "blocks.4.attn._attention_pool_k.pool.weight", "blocks.4.attn._attention_pool_k.norm.weight", "blocks.4.attn._attention_pool_k.norm.bias", "blocks.4.attn._attention_pool_v.pool.weight", "blocks.4.attn._attention_pool_v.norm.weight", "blocks.4.attn._attention_pool_v.norm.bias", "blocks.5.attn._attention_pool_k.pool.weight", "blocks.5.attn._attention_pool_k.norm.weight", "blocks.5.attn._attention_pool_k.norm.bias", "blocks.5.attn._attention_pool_v.pool.weight", "blocks.5.attn._attention_pool_v.norm.weight", "blocks.5.attn._attention_pool_v.norm.bias", "blocks.6.attn._attention_pool_k.pool.weight", "blocks.6.attn._attention_pool_k.norm.weight", "blocks.6.attn._attention_pool_k.norm.bias", "blocks.6.attn._attention_pool_v.pool.weight", "blocks.6.attn._attention_pool_v.norm.weight", "blocks.6.attn._attention_pool_v.norm.bias", "blocks.7.attn._attention_pool_k.pool.weight", "blocks.7.attn._attention_pool_k.norm.weight", "blocks.7.attn._attention_pool_k.norm.bias", "blocks.7.attn._attention_pool_v.pool.weight", "blocks.7.attn._attention_pool_v.norm.weight", "blocks.7.attn._attention_pool_v.norm.bias", "blocks.8.attn._attention_pool_k.pool.weight", "blocks.8.attn._attention_pool_k.norm.weight", "blocks.8.attn._attention_pool_k.norm.bias", "blocks.8.attn._attention_pool_v.pool.weight", "blocks.8.attn._attention_pool_v.norm.weight", "blocks.8.attn._attention_pool_v.norm.bias", "blocks.9.attn._attention_pool_k.pool.weight", "blocks.9.attn._attention_pool_k.norm.weight", "blocks.9.attn._attention_pool_k.norm.bias", "blocks.9.attn._attention_pool_v.pool.weight", "blocks.9.attn._attention_pool_v.norm.weight", "blocks.9.attn._attention_pool_v.norm.bias", "blocks.10.attn._attention_pool_k.pool.weight", "blocks.10.attn._attention_pool_k.norm.weight", "blocks.10.attn._attention_pool_k.norm.bias", "blocks.10.attn._attention_pool_v.pool.weight", "blocks.10.attn._attention_pool_v.norm.weight", "blocks.10.attn._attention_pool_v.norm.bias", "blocks.11.attn._attention_pool_k.pool.weight", "blocks.11.attn._attention_pool_k.norm.weight", "blocks.11.attn._attention_pool_k.norm.bias", "blocks.11.attn._attention_pool_v.pool.weight", "blocks.11.attn._attention_pool_v.norm.weight", "blocks.11.attn._attention_pool_v.norm.bias", "blocks.12.attn._attention_pool_k.pool.weight", "blocks.12.attn._attention_pool_k.norm.weight", "blocks.12.attn._attention_pool_k.norm.bias", "blocks.12.attn._attention_pool_v.pool.weight", "blocks.12.attn._attention_pool_v.norm.weight", "blocks.12.attn._attention_pool_v.norm.bias", "blocks.13.attn._attention_pool_k.pool.weight", "blocks.13.attn._attention_pool_k.norm.weight", "blocks.13.attn._attention_pool_k.norm.bias", "blocks.13.attn._attention_pool_v.pool.weight", "blocks.13.attn._attention_pool_v.norm.weight", "blocks.13.attn._attention_pool_v.norm.bias", "blocks.14.attn._attention_pool_q.pool.weight", "blocks.14.attn._attention_pool_q.norm.weight", "blocks.14.attn._attention_pool_q.norm.bias", "blocks.14.attn._attention_pool_k.pool.weight", "blocks.14.attn._attention_pool_k.norm.weight", "blocks.14.attn._attention_pool_k.norm.bias", "blocks.14.attn._attention_pool_v.pool.weight", "blocks.14.attn._attention_pool_v.norm.weight", "blocks.14.attn._attention_pool_v.norm.bias", "blocks.15.attn._attention_pool_k.pool.weight", "blocks.15.attn._attention_pool_k.norm.weight", "blocks.15.attn._attention_pool_k.norm.bias", "blocks.15.attn._attention_pool_v.pool.weight", "blocks.15.attn._attention_pool_v.norm.weight", "blocks.15.attn._attention_pool_v.norm.bias". 
```

This happens because the newly introduced `_attention_pool_*` modules don't get their weights loaded. Though they are not used, the missing keys cause the weight loading to fail. A workaround is to do:
```python
path = "/path/to/manually/downloaded/MVIT_B_16x4.pyth"
model.load_state_dict(torch.load(path)["model_state"], strict=False)
```

This PR fixes the issue by using the PyTorch `_load_from_state_dict()` API to offer BC across models. Though the module can be rewritten to be simplified, this might have BC effects. The proposed solution solves this by just copying the weights on-the-fly prior loading.

The patch was tested as follows:
```python
import torch
from pytorchvideo.models.hub.vision_transformers import mvit_base_16x4


# Works before the patch
m1 = mvit_base_16x4().eval()
m1.load_state_dict(
    torch.load("MVIT_B_16x4.pyth")["model_state"], strict=False
)

# Works after the patch
m2 = mvit_base_16x4(pretrained=True).eval()


batch = torch.randn((4, 3, 16, 224, 224))
y1 = m1(batch)
y2 = m2(batch)
assert torch.equal(y1, y2)

print("OK")
```