### PR TITLE
Add torch.fx to the imports.

### DIFF
--- a/pytorchvideo/layers/attention.py
+++ b/pytorchvideo/layers/attention.py
@@ -4,6 +4,7 @@ from typing import Callable, List, Optional, Tuple
 
 import numpy
 import torch
+import torch.fx
 import torch.nn as nn
 from torch.nn.common_types import _size_3_t
 


### PR DESCRIPTION
## Motivation and Context

Without this fix, torch.fx needs to already be imported by the caller in order to import this module.

## How Has This Been Tested

By importing pytorchvideo.layers.attention

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

