### PR TITLE
Fix failing test_video_transform_factory

### DIFF
--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -1084,8 +1084,8 @@ class TestTransforms(unittest.TestCase):
         self.assertTrue(
             video_dict_transformed["video"].equal(video_comp_transformed["video"])
         )
-        self.assertTrue(
-            video_frame_transformed.equal(video_tensor_transformed[:, 0:1, :, :])
+        torch.testing.assert_close(
+            video_frame_transformed, video_tensor_transformed[:, 0:1, :, :]
         )
         c, t, h, w = video_dict_transformed["video"].shape
         self.assertEqual(c, 3)


### PR DESCRIPTION
Summary:
This PR fixes the currently failing https://www.internalfb.com/intern/test/844424967130487/ by using a more appropriate check: one shouldn't use hard `assert == ` on float values as floating point differences can always happen.

The test started failing after  D40217870 was merged, which allowed for a faster path in the `interpolate()` operator for some images / masks. The results of the 2 paths are equivalent (up to floating points approximation).

Merging this fix would avoid having to land the revert diff D40255846

Reviewed By: datumbox

Differential Revision: D40261058

