### PR TITLE
Updated Swish function to enable model export

### DIFF
--- a/pytorchvideo/layers/swish.py
+++ b/pytorchvideo/layers/swish.py
@@ -10,6 +10,12 @@ class Swish(nn.Module):
     """
 
     def forward(self, x):
+        if not self.training:
+            """
+            SwishFunction is not traceable by torchscript due to use of torch.autograd
+            Apply model.eval() before tracing using torch.jit.trace
+            """
+            return x * torch.sigmoid(x)
         return SwishFunction.apply(x)
 
 


### PR DESCRIPTION
## Motivation and Context

SwishFunction is not exportable due to memory efficient implementation using `torch.autograd`. I have added simplified swish function in eval model to enable export.

Issue: https://github.com/facebookresearch/pytorchvideo/issues/184

Utilisation (torchscript):

`model.eval()`
`traced_model = torch.jit.trace(model, input)`

Utilisation (onnx):

`model.eval()`
`torch.onnx.export(model, input, ......)`

Utilisation (tensorRT):

`from torch2trt import torch2trt`
`model.eval()`
`model_trt = torch2trt(model, ...)`


## How Has This Been Tested

I have tested the implementation myself, but I have not created a test for it.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

