### PR TITLE
Added missing type hint to EncodedVideo.from_path()'s return value

### DIFF
--- a/pytorchvideo/data/encoded_video.py
+++ b/pytorchvideo/data/encoded_video.py
@@ -53,7 +53,7 @@ class EncodedVideo(Video):
         decode_audio: bool = True,
         decoder: str = "pyav",
         **other_args: Dict[str, Any],
-    ):
+    ) -> Video:
         """
         Fetches the given video path using PathManager (allowing remote uris to be
         fetched) and constructs the EncodedVideo object.


### PR DESCRIPTION
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->
If a user loads a video through the `EncodedVideo.from_path` method, they will not get any type hints for that video in their IDE because that method does not specify its return type. This PR fixes that.

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->
The method was called from another Python script. Since I just added a type hint and no syntax errors were raised, there's no possibility for anything to have broken.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [not necessary] I have added tests to cover my changes.
- [not necessary] All new and existing tests passed.

