### PR TITLE
Use torchdynamo compatible backward API for Swish

### DIFF
--- a/pytorchvideo/layers/swish.py
+++ b/pytorchvideo/layers/swish.py
@@ -29,6 +29,6 @@ class SwishFunction(torch.autograd.Function):
 
     @staticmethod
     def backward(ctx, grad_output):
-        x = ctx.saved_variables[0]
+        (x,) = ctx.saved_tensors
         sigmoid_x = torch.sigmoid(x)
         return grad_output * (sigmoid_x * (1 + x * (1 - sigmoid_x)))


### PR DESCRIPTION
Summary:
Trying to trace a graph that used this Swish function with torchdynamo resulted
in this error:
```lang=text
torch._dynamo.variables.higher_order_ops: [WARNING] speculate_subgraph: while introspecting the user-defined autograd.Function, we were unable to trace function `trampoline_autograd_bwd` into a single graph.
This means that Dynamo was unable to prove safety for this API and will fall back to eager-mode PyTorch, which could lead to a slowdown.
torch._dynamo.exc.Unsupported: call_method GetAttrVariable(AutogradFunctionContextVariable(Function), saved_variables) __getitem__ (ConstantVariable(int),) {}
```

According to the modern pytorch tutorials, the attribute that should be used from the
autograd context is `saved_tensors` instead, which fixes the trace issue I saw.

I used this website for guidance:
https://pytorch.org/docs/stable/generated/torch.autograd.function.FunctionCtx.save_for_backward.html

Differential Revision: D49398231


