### PR TITLE
Add grayscale transform for videos

### DIFF
--- a/pytorchvideo/transforms/transforms.py
+++ b/pytorchvideo/transforms/transforms.py
@@ -339,6 +339,22 @@ class Permute(torch.nn.Module):
         return x.permute(*self._dims)
 
 
+class Grayscale(torchvision.transforms.Grayscale):
+    """
+    Converts RGB frames of (CTHW) video clip to grayscale.
+    """
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """
+        Args:
+            x (torch.Tensor): video tensor with shape (C, T, H, W).
+        """
+        vid = x.permute(1, 0, 2, 3)
+        vid = super().forward(vid)
+        vid = vid.permute(1, 0, 2, 3)
+        return vid
+
+
 class OpSampler(torch.nn.Module):
     """
     Given a list of transforms with weights, OpSampler applies weighted sampling to


### PR DESCRIPTION
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
The grayscale transformation for video is used in video action classification approaches to accelerate training.
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
The result of grayscale transform is compared to frame-wise torchvision.transforms.grayscale transformation.
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

