### PR TITLE
[bug fix] handle different tensor devices in functional.uniform_tempo…

### DIFF
--- a/pytorchvideo/transforms/functional.py
+++ b/pytorchvideo/transforms/functional.py
@@ -38,6 +38,8 @@ def uniform_temporal_subsample(
     # Sample by nearest neighbor interpolation if num_samples > t.
     indices = torch.linspace(0, t - 1, num_samples)
     indices = torch.clamp(indices, 0, t - 1).long()
+    if indices.device != x.device:
+        indices = indices.to(x.device)
     return torch.index_select(x, temporal_dim, indices)
 
 


### PR DESCRIPTION
## Motivation and Context

As reported in #256 , when the input tensor has some non-default device type, the code `transforms.functional.uniform_temporal_subsample` failed to run. The problem could be reproduced if we set some default device at global level, and then passing in tensor with a non-default device to uniform_temporal_subsample.

The proposed code add a check, if the indices and the input x have the same device.
```
    if indices.device != x.device:
        indices = indices.to(x.device)
```

## How Has This Been Tested

1. Set default device at global level
```
torch.set_default_device('cuda')
```

2. Use `load_and_transform_video_data` from ImageBind to process some video data https://github.com/facebookresearch/ImageBind/blob/c6a47d6dc2b53eced51d398c181d57049ca59286/imagebind/data.py#L287

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

